### PR TITLE
Extract comodo engine version

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -88,7 +88,7 @@ func AvScan(path string, timeout int) Comodo {
 // ParseComodoOutput convert comodo output into ResultsData struct
 func ParseComodoOutput(comodoout string) ResultsData {
 
-	comodo := ResultsData{Infected: false, Engine: "1.1", Updated: getUpdatedDate()}
+	comodo := ResultsData{Infected: false, Engine: getComodoVersion(), Updated: getUpdatedDate()}
 
 	log.Debug("comodoout: ", comodoout)
 
@@ -141,6 +141,21 @@ func updateAV() error {
 	t := time.Now().Format("20060102")
 	err = ioutil.WriteFile("/opt/malice/UPDATED", []byte(t), 0644)
 	return err
+}
+
+func getComodoVersion() string {
+	versionOut, err := utils.RunCommand(nil, "/bin/cat", "/opt/COMODO/etc/COMODO.xml")
+	assert(err)
+
+	log.Debug("Comodo Version: ", versionOut)
+	for _, line := range strings.Split(versionOut, "\n") {
+		if len(line) != 0 {
+			if strings.Contains(line, "<ProductVersion>") {
+				return strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "<ProductVersion>"), "</ProductVersion>"))
+			}
+		}
+	}
+	return "error"
 }
 
 func getUpdatedDate() string {

--- a/scan.go
+++ b/scan.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -144,15 +145,17 @@ func updateAV() error {
 }
 
 func getComodoVersion() string {
-	versionOut, err := utils.RunCommand(nil, "/bin/cat", "/opt/COMODO/etc/COMODO.xml")
+	file, err := os.Open("/opt/COMODO/etc/COMODO.xml")
 	assert(err)
+	defer file.Close()
 
-	log.Debug("Comodo Version: ", versionOut)
-	for _, line := range strings.Split(versionOut, "\n") {
-		if len(line) != 0 {
-			if strings.Contains(line, "<ProductVersion>") {
-				return strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "<ProductVersion>"), "</ProductVersion>"))
-			}
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, "<ProductVersion>") {
+			versionOut := strings.TrimSpace(strings.Replace(strings.Replace(line, "<ProductVersion>", "", 1), "</ProductVersion>", "", 1))
+			log.Debug("Comodo Version: ", versionOut)
+			return versionOut
 		}
 	}
 	return "error"


### PR DESCRIPTION
The comodo engine version seems to be stored in /opt/COMODO/etc/COMODO.xml. This PR extracts the version from this file instead of using the hard coded string "1.1".

*Explination*
Comodo software versions are quite confusing to me. If you open cav and click about, it'll report the version as 1.1.268025.1 which is consistent to the content of the file /opt/COMODO/cavver.dat and this comodo forum thread: https://forums.comodo.com/comodo-antivirus-for-linux-cavl/comodo-antivirus-for-linux-cavl-v112680251-is-released-t92199.0.html.

In the file referred to above, you'll find the version "5.0.163652.1142" noted as AntivirusPro ProductVersion. This version is existent in the file created when you export your comodo configuration (cav => more => manage my configurations) as well. A google search reveals an existing cve for this comodo "version", see https://www.cvedetails.com/version/125322/Comodo-Comodo-Internet-Security-5.0.163652.1142.html.

I've no idea which version is the engine. My guess is, that 1.1.x is the version of the linux gui application and 5.x is the version of the engine. What do you think?